### PR TITLE
Added better documentation comments to all the code. 

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -1,24 +1,34 @@
+//! Demonstrates the fundamental concepts of creating and using a terminal window.
+
 use minui::{Window, Event, TerminalWindow};
 
-// This example shows the minimal workflow:
-//  - Create a window
-//  - Write some text
-//  - Enter an input loop
-//  - Handle different types of input events
-//  - Clean up automatically when done
-
+/// Basic example showing core window operations and input handling.
+///
+/// This example demonstrates:
+/// 1. Creating and initializing a terminal window
+/// 2. Writing text to the screen
+/// 3. Handling keyboard input events
+/// 4. Proper cleanup (handled automatically by Drop)
 fn main() -> minui::Result<()> {
+    // Create a new terminal window in raw mode
     let mut window = TerminalWindow::new()?;
+    // Clear the screen to start fresh
     window.clear()?;
 
+    // Display instructions at the top of the screen (position 0,0)
     window.write_str(0, 0, "Press 'q' to quit")?;
 
+    // Main event loop - keep running until 'q' is pressed
     loop {
+        // Wait for and handle the next keyboard input
         match window.get_input()? {
+            // Exit the program when 'q' is pressed
             Event::Character('q') => break,
+            // For other character keys, show what was pressed
             Event::Character(c) => {
                 window.write_str(1, 0, &format!("You pressed: {}", c))?;
             }
+            // For special keys (arrows, etc), show the event type
             evt => {
                 window.write_str(1, 0, &format!("Event: {:?}", evt))?;
             }

--- a/examples/color_usage.rs
+++ b/examples/color_usage.rs
@@ -1,13 +1,23 @@
+//! Demonstrates the various ways to use colors in terminal output.
+
 use minui::{Window, Event, Result, Color, ColorPair, TerminalWindow};
 
+/// Example showing how to use colors for terminal text.
+///
+/// This example demonstrates:
+/// 1. Writing plain vs colored text
+/// 2. Using different foreground colors
+/// 3. Using background colors
+/// 4. Common use cases for colored output (errors, warnings, etc.)
 fn main() -> Result<()> {
+    // Initialize the terminal window
     let mut window = TerminalWindow::new()?;
     window.clear()?;
 
-    // Write regular text
+    // Display title at the top
     window.write_str(0, 0, "Color Demo (press 'q' to quit)")?;
 
-    // Show all colors on black background
+    // Demonstrate all available foreground colors on black background
     let colors = [
         Color::Red,
         Color::Green,
@@ -18,17 +28,18 @@ fn main() -> Result<()> {
         Color::White,
     ];
 
+    // Display each color name in its corresponding color
     for (i, &color) in colors.iter().enumerate() {
         let color_pair = ColorPair::new(color, Color::Black);
         window.write_str_colored(
-            2,
-            (i as u16) * 10,
+            2,                     // Row 2
+            (i as u16) * 10,      // Column 0, 10, 20, etc.
             &format!("{:?}", color),
             color_pair
         )?;
     }
 
-    // Show some example colored text
+    // Show practical examples of color usage for different types of messages
     window.write_str_colored(
         4, 0,
         "Error: Something went wrong!",
@@ -47,13 +58,14 @@ fn main() -> Result<()> {
         ColorPair::new(Color::Yellow, Color::Black)
     )?;
 
+    // Example of using background color for emphasis
     window.write_str_colored(
         7, 0,
         "URGENT: System failure! jk :)",
         ColorPair::new(Color::Black, Color::Red)
     )?;
 
-    // Wait for 'q' to quit
+    // Input loop
     loop {
         match window.get_input()? {
             Event::Character('q') => break,

--- a/examples/custom_colors.rs
+++ b/examples/custom_colors.rs
@@ -1,21 +1,34 @@
+//! Demonstrates how to define and use custom color combinations.
+
 use minui::{Window, Event, Result, Color, ColorPair, define_colors, TerminalWindow};
 
-// Users can easily define their color schemes
+// Define a custom color scheme using the define_colors! macro.
+// This creates constant ColorPair values that can be used throughout the program.
 define_colors! {
+    // Color pairs for UI status messages
     pub const UI_WARNING = (Color::Yellow, Color::Black);
     pub const UI_ERROR = (Color::Red, Color::Black);
     pub const UI_SUCCESS = (Color::Green, Color::Black);
+
+    // Color pairs for different players or game elements
     pub const PLAYER_ONE = (Color::Black, Color::Cyan);
     pub const PLAYER_TWO = (Color::Black, Color::Magenta);
 }
 
+/// Example showing how to create and use custom color schemes.
+///
+/// This example demonstrates:
+/// 1. Defining reusable color combinations
+/// 2. Using the define_colors! macro
+/// 3. Creating semantic color constants
+/// 4. Applying consistent colors across an application
 fn main() -> Result<()> {
     let mut window = TerminalWindow::new()?;
     window.clear()?;
 
     window.write_str(0, 0, "Custom color demo (press 'q' to quit)")?;
 
-    // Now the predefined colors can be used directly
+    // Use the predefined color pairs for consistent styling
     window.write_str_colored(2, 0, "Warning message", UI_WARNING)?;
     window.write_str_colored(3, 0, "Error message", UI_ERROR)?;
     window.write_str_colored(4, 0, "Success message", UI_SUCCESS)?;

--- a/examples/widget_usage.rs
+++ b/examples/widget_usage.rs
@@ -1,3 +1,6 @@
+//! Demonstrates how to create, configure, and combine different widget types
+//! to create a rich terminal user interface.
+
 use minui::{
     TerminalWindow,
     Event,
@@ -7,61 +10,86 @@ use minui::{
     widgets::{Container, BorderChars, Widget, Label, Alignment, Panel, TextBlock, TextWrapMode, VerticalAlignment}
 };
 
+/// Example demonstrating various widgets and their features.
+///
+/// This example shows:
+/// - Panel with styled header and body
+/// - Container with centered label
+/// - Standalone floating label
+/// - Text block with word wrapping
+/// - Different border styles
+/// - Color usage
+/// - Widget positioning and alignment
 fn main() -> Result<()> {
-    // Initialize the window
+    // Create and initialize the terminal window
     let mut window = TerminalWindow::new()?;
 
-    // Info panel with different border styles and colors
+    // Create a panel with a header and styled borders
+    // This demonstrates:
+    // - Different border styles for header and body
+    // - Text and border coloring
+    // - Centered text alignment
+    // - Content padding
     let info_panel = Panel::new(0, 0, 40, 10)
         .with_header("Welcome to MinUI")
         .with_body("This demo shows different panel styles & features.\n\nPress 'q' to quit.")
-        .with_header_style(BorderChars::double_line())
+        .with_header_style(BorderChars::double_line())           // ╔═══╗ style for header
         .with_header_color(Some(ColorPair::new(Color::Blue, Color::Transparent)))
         .with_header_border_color(Color::Blue)
-        .with_body_style(BorderChars::single_line())
+        .with_body_style(BorderChars::single_line())            // ┌───┐ style for body
         .with_alignment(Alignment::Center)
         .with_padding(1);
 
-
-    // Define the label to be used in a container here...
+    // Create a centered label to be placed inside a container
+    // Note that for labels in containers, position is relative to the container
     let info_label = Label::new(0, 1, "This is a double-line container")
         .with_alignment(Alignment::Center);
 
-    // ...and then make the container with that label inside it!
+    // Create a container using double-line borders and the label above
+    // The container will automatically size itself to fit the label
     let info_container = Container::new(0, 11, 0, 5)
         .with_style(BorderChars::double_line())
         .with_content(info_label);
 
-
-    // If a label is not used in a container, its defined position is absolute and not relative to
-    // the container position
+    // Create a standalone label with absolute positioning
+    // This label isn't contained within any other widget, so its
+    // coordinates are relative to the window
     let floating_label = Label::new(5, 9, "Floating label, spooky!")
         .with_text_color(Color::Red);
 
-
-    // You can also put extra-long text boxes inside a container, with specified behaviors
+    // Create a text block with word wrapping and styling
+    // This demonstrates:
+    // - Word-based text wrapping
+    // - Centered text alignment
+    // - Vertical alignment
+    // - Background colors
     let text_block = TextBlock::new(0, 0, 40, 5,
                                     "This is supposed to be a really long block of text, \
-                                    maybe the description of an item in a game, or some lore \
-                                    paragraph. I don't know, do whatever you want :)"
+         maybe the description of an item in a game, or some lore \
+         paragraph. I don't know, do whatever you want :)"
     )
         .with_colors(ColorPair::new(Color::White, Color::Blue))
         .with_wrap_mode(TextWrapMode::WrapWords)
         .with_alignment(Alignment::Center, VerticalAlignment::Middle);
 
+    // Create a container for the text block using ASCII borders
+    // This demonstrates:
+    // - Automatic sizing based on content
+    // - ASCII border style (+--+)
+    // - Container positioning
     let paragraph_container = Container::new(42, 9, 0, 0)
         .with_auto_size(true)
         .with_style(BorderChars::ascii())
         .with_content(text_block);
 
-
-    // Draw all the widgets
+    // Draw all widgets to the screen
+    // Order matters - widgets drawn later will appear on top
     info_panel.draw(&mut window)?;
     info_container.draw(&mut window)?;
     floating_label.draw(&mut window)?;
     paragraph_container.draw(&mut window)?;
 
-    // Wait for a keypress before closing
+    // Wait for 'q' to be pressed before exiting
     loop {
         if let Ok(event) = window.get_input() {
             if let Event::Character('q') = event {

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,6 +1,14 @@
+//! Terminal color definitions and styling utilities.
+//!
+//! Provides type-safe color handling and conversion for terminal output,
+//! supporting both foreground and background colors.
+
 use crossterm::style::{Color as CrosstermColor};
 
-/// Represents the basic terminal colors available for text foreground and background
+/// Available colors for terminal text and backgrounds.
+///
+/// Provides a simplified set of the most common terminal colors, plus
+/// a Transparent option for removing color styling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Color {
     Black,
@@ -11,11 +19,24 @@ pub enum Color {
     Magenta,
     Cyan,
     White,
-    Transparent
+    Transparent // No color (terminal default)
 }
 
 impl Color {
-    /// Converts the Color enum to crossterm's Color types for terminal output
+    /// Converts to the crossterm library's color type for terminal output.
+    ///
+    /// This method is primarily used internally by the library to convert
+    /// the color enum to crossterm's representation when writing to the terminal.
+    /// I suppose it could be used as described below.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use minui::Color;
+    ///
+    /// let color = Color::Blue;
+    /// let crossterm_color = color.to_crossterm();
+    /// ```
     pub fn to_crossterm(self) -> CrosstermColor {
         match self {
             Color::Black => CrosstermColor::Black,
@@ -31,7 +52,10 @@ impl Color {
     }
 }
 
-/// Represents a foreground and background color pair for terminal styling
+/// A pair of foreground and background colors for terminal styling.
+///
+/// Combines two colors to define the complete styling for a piece of text,
+/// where `fg` is the text color and `bg` is the background color.
 #[derive(Debug, Clone, Copy)]
 pub struct ColorPair {
     pub fg: Color,
@@ -39,7 +63,16 @@ pub struct ColorPair {
 }
 
 impl ColorPair {
-    /// Creates a new specified ColorPair as described above
+    /// Creates a new color pair with specified foreground and background colors.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use minui::{Color, ColorPair};
+    ///
+    /// // Create yellow text on black background
+    /// let warning_style = ColorPair::new(Color::Yellow, Color::Black);
+    /// ```
     pub const fn new(fg: Color, bg: Color) -> Self {
         Self { fg, bg }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,20 +1,49 @@
+//! Error types and handling for the minui library.
+//!
+//! Defines a comprehensive error handling system using custom error types
+//! that cover various failure modes in terminal applications.
+
 use thiserror::Error;
 
-/// Custom error types for the terminal application
+/// Possible errors that can occur in terminal applications.
+///
+/// This enum covers the main categories of errors that can occur when
+/// working with terminal interfaces, including initialization, window
+/// operations, input handling, and I/O errors.
+///
+/// # Example
+///
+/// ```rust
+/// use minui::{Result, Error};
+///
+/// fn initialize_component() -> Result<()> {
+///     if some_condition {
+///         return Err(Error::InitializationError("Failed to start".into()));
+///     }
+///     Ok(())
+/// }
+/// ```
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Errors that occur during terminal initialization
     #[error("Failed to initialize terminal: {0}")]
     InitializationError(String),
 
+    /// Errors related to window operations (e.g., writing out of bounds)
     #[error("Window operation failed: {0}")]
     WindowError(String),
 
+    /// Errors caused by invalid user input
     #[error("Invalid Input: {0}")]
     InputError(String),
 
+    /// Underlying I/O errors from the terminal
     #[error("IO error: {0}")]
     IOError(#[from] std::io::Error),
 }
 
-/// Result type alias using custom Error type
+/// Convenience type alias for Results using the custom Error type.
+///
+/// This type alias simplifies error handling throughout the library by
+/// providing a standard Result type with the custom Error enum.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,22 @@
-/// Represents the keyboard input events that can be handled by the application
+/// Represents keyboard input events handled by the application.
+///
+/// This enum covers the common keyboard inputs needed for terminal user
+/// interfaces, including regular characters, special keys, and function keys.
+///
+/// # Example
+///
+/// ```rust
+/// use minui::Event;
+///
+/// fn handle_input(event: Event) {
+///     match event {
+///         Event::Character('q') => println!("Quit pressed"),
+///         Event::KeyUp => println!("Up arrow pressed"),
+///         Event::Enter => println!("Enter pressed"),
+///         _ => println!("Other key pressed"),
+///     }
+/// }
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub enum Event {
     Character(char),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,24 @@
-/// Defines constant ColorPair values using a more concise syntax
-/// Example: define_colors! { pub const HIGHLIGHTED = (Color::White, Color::Blue); }
+/// Defines constant ColorPair values using a concise syntax.
+///
+/// This macro simplifies the creation of constant ColorPair values by providing
+/// a more readable syntax. It accepts multiple color pair definitions in the form
+/// of `pub const NAME = (foreground_color, background_color)`.
+///
+/// # Example
+///
+/// ```rust
+/// use minui::{define_colors, Color};
+///
+/// define_colors! {
+///     pub const ERROR = (Color::White, Color::Red);
+///     pub const SUCCESS = (Color::Black, Color::Green);
+///     pub const HIGHLIGHT = (Color::Black, Color::Yellow);
+/// }
+///
+/// // Use the defined colors
+/// let error_box = Container::new(0, 0, 40, 3)
+///     .with_border_color(ERROR.fg);
+/// ```
 #[macro_export]
 macro_rules! define_colors {
     ($(pub const $name:ident = ($fg:expr, $bg:expr);)*) => {

--- a/src/widgets/common.rs
+++ b/src/widgets/common.rs
@@ -1,6 +1,29 @@
+//! Common utilities and helper types for widget implementation.
+//!
+//! This module provides shared functionality used across the minui library, including:
+//! - Border drawing characters and styles
+//! - Window view management for nested widgets
+//! - Common trait implementations
+
 use crate::{ColorPair, Result, Window};
 
-/// Characters used for drawing widget borders
+/// Characters used for drawing widget borders with different styles.
+///
+/// Provides a collection of characters needed to draw complete borders around widgets,
+/// including corners, edges, and intersection points for nested borders. Includes
+/// predefined sets for different visual styles through associated functions.
+///
+/// # Example
+///
+/// ```rust
+/// use minui::BorderChars;
+///
+/// // Use single-line border style
+/// let border = BorderChars::single_line();
+/// println!("{0}{1}{2}", border.top_left, border.horizontal, border.top_right);
+/// println!("{0} {0}", border.vertical);
+/// println!("{0}{1}{2}", border.bottom_left, border.horizontal, border.bottom_right);
+/// ```
 #[derive(Debug, Clone, Copy)]
 pub struct BorderChars {
     pub top_left: char,
@@ -17,6 +40,10 @@ pub struct BorderChars {
 }
 
 impl BorderChars {
+    /// Creates a set of single-line border characters (┌─┐│└┘).
+    ///
+    /// These characters use Unicode box-drawing symbols to create thin,
+    /// single-line borders suitable for most UI elements.
     pub const fn single_line() -> Self {
         Self {
             top_left: '┌',
@@ -33,6 +60,10 @@ impl BorderChars {
         }
     }
 
+    /// Creates a set of double-line border characters (╔═╗║╚╝).
+    ///
+    /// These characters use Unicode box-drawing symbols to create thick,
+    /// double-line borders for emphasis or special UI elements.
     pub const fn double_line() -> Self {
         Self {
             top_left: '╔',
@@ -49,6 +80,10 @@ impl BorderChars {
         }
     }
 
+    /// Creates a set of ASCII-compatible border characters (+-|).
+    ///
+    /// Uses standard ASCII characters for borders, ensuring compatibility
+    /// with terminals that don't support Unicode box-drawing characters.
     pub const fn ascii() -> Self {
         Self {
             top_left: '+',
@@ -66,7 +101,32 @@ impl BorderChars {
     }
 }
 
-/// Helper struct for drawing within widget bounds
+/// Helper struct for drawing within constrained widget bounds.
+///
+/// `WindowView` wraps a window reference and provides coordinate translation,
+/// allowing nested widgets to use local coordinates while respecting their
+/// parent's boundaries. This enables proper containment and layout management
+/// for complex widget hierarchies.
+///
+/// The view maintains:
+/// - A reference to the parent window
+/// - X and Y offsets for coordinate translation
+/// - Width and height constraints
+///
+/// # Example
+///
+/// ```rust
+/// use minui::{Window, WindowView};
+///
+/// fn draw_in_bounds(view: &mut WindowView) -> Result<()> {
+///     // Coordinates are relative to the view's bounds
+///     view.write_str(0, 0, "Top-left of view")?;
+///
+///     // Automatically translates to proper screen coordinates
+///     // and respects boundary constraints
+///     Ok(())
+/// }
+/// ```
 pub struct WindowView<'a> {
     pub window: &'a mut dyn Window,
     pub x_offset: u16,
@@ -76,6 +136,10 @@ pub struct WindowView<'a> {
 }
 
 impl<'a> Window for WindowView<'a> {
+    /// Writes a string at the specified position, translated to parent coordinates.
+    ///
+    /// Positions are relative to the view's bounds. Writing outside the view's
+    /// bounds is silently ignored to prevent buffer overflow.
     fn write_str(&mut self, y: u16, x: u16, s: &str) -> Result<()> {
         if y < self.height && x < self.width {
             self.window.write_str(
@@ -88,6 +152,10 @@ impl<'a> Window for WindowView<'a> {
         }
     }
 
+    /// Writes a colored string at the specified position, translated to parent coordinates.
+    ///
+    /// Similar to `write_str`, but with color support. Positions are relative to the
+    /// view's bounds and out-of-bounds writes are silently ignored.
     fn write_str_colored(&mut self, y: u16, x: u16, s: &str, colors: ColorPair) -> Result<()> {
         if y < self.height && x < self.width {
             self.window.write_str_colored(
@@ -101,6 +169,7 @@ impl<'a> Window for WindowView<'a> {
         }
     }
 
+    /// Returns the size of the view's bounds.
     fn get_size(&self) -> (u16, u16) {
         (self.width, self.height)
     }

--- a/src/widgets/container.rs
+++ b/src/widgets/container.rs
@@ -1,7 +1,30 @@
 use crate::{Window, Result, ColorPair, Color};
 use super::{BorderChars, Widget, WindowView};
 
-/// Basic four-sided rectangular frame widget. Can contain other widgets.
+/// A rectangular frame widget that can contain other widgets.
+///
+/// Container is a fundamental layout widget that draws a bordered box and can
+/// hold another widget as its content. It supports:
+/// - Customizable border styles (single-line, double-line, ASCII)
+/// - Optional border colors
+/// - Content padding
+/// - Automatic sizing based on content
+///
+/// The container automatically manages its content's positioning and clipping
+/// within its bounds.
+///
+/// # Example
+///
+/// ```rust
+/// use minui::{Container, Label, Color, BorderChars};
+///
+/// // Create a blue container with a label
+/// let container = Container::new(0, 0, 40, 3)
+///     .with_border_color(Color::Blue)
+///     .with_style(BorderChars::double_line())
+///     .with_padding(1)
+///     .with_content(Label::new(0, 0, "Hello, World!"));
+/// ```
 pub struct Container {
     x: u16,
     y: u16,
@@ -15,6 +38,19 @@ pub struct Container {
 }
 
 impl Container {
+    /// Creates a new container with the specified position and size.
+    ///
+    /// By default, the container:
+    /// - Uses single-line borders
+    /// - Has no border color
+    /// - Has 1 unit of padding
+    /// - Automatically sizes to its content
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let container = Container::new(0, 0, 40, 3);
+    /// ```
     pub fn new(x: u16, y: u16, width: u16, height: u16) -> Self {
         Self {
             x,
@@ -25,20 +61,49 @@ impl Container {
             border_color: None,
             content: None,
             padding: 1,
-            auto_size: true, // Auto sizes the container by default
+            auto_size: true,
         }
     }
 
+    /// Sets the border style using a BorderChars configuration.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let container = Container::new(0, 0, 40, 3)
+    ///     .with_style(BorderChars::double_line());
+    /// ```
     pub fn with_style(mut self, style: BorderChars) -> Self {
         self.style = style;
         self
     }
 
+    /// Sets the border color using a single Color.
+    ///
+    /// The background color is automatically set to Transparent.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let container = Container::new(0, 0, 40, 3)
+    ///     .with_border_color(Color::Blue);
+    /// ```
     pub fn with_border_color(mut self, color: Color) -> Self {
         self.border_color = Some(ColorPair::new(color, Color::Transparent));
         self
     }
 
+    /// Sets the container's content to the specified widget.
+    ///
+    /// If auto_size is enabled (default), the container will
+    /// adjust its size to fit the content plus padding and borders.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let container = Container::new(0, 0, 40, 3)
+    ///     .with_content(Label::new(0, 0, "Content"));
+    /// ```
     pub fn with_content(mut self, widget: impl Widget + 'static) -> Self {
         self.content = Some(Box::new(widget));
         if self.auto_size {
@@ -47,16 +112,39 @@ impl Container {
         self
     }
 
+    /// Sets the padding between the container's borders and its content.
+    ///
+    /// Padding is applied equally to all sides.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let container = Container::new(0, 0, 40, 3)
+    ///     .with_padding(2);  // 2 units of padding on all sides
+    /// ```
     pub fn with_padding(mut self, padding: u16) -> Self {
         self.padding = padding;
         self
     }
 
+    /// Enables or disables automatic sizing based on content.
+    ///
+    /// When enabled, the container will adjust its size to fit its
+    /// content plus padding and borders. When disabled, it will
+    /// maintain its original size.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let container = Container::new(0, 0, 40, 3)
+    ///     .with_auto_size(false);  // Keep fixed size
+    /// ```
     pub fn with_auto_size(mut self, auto_size: bool) -> Self {
         self.auto_size = auto_size;
         self
     }
 
+    /// Calculates the size needed to fit the content plus padding and borders.
     fn adjust_size_to_content(&mut self) {
         if let Some(widget) = &self.content {
             let (content_width, content_height) = widget.get_size();
@@ -65,18 +153,26 @@ impl Container {
         }
     }
 
+    /// Returns the internal dimensions available for content.
     fn get_inner_dimensions(&self) -> (u16, u16) {
         let inner_width = self.width.saturating_sub(2);
         let inner_height = self.height.saturating_sub(2);
         (inner_width, inner_height)
     }
 
+    /// Returns the position where content should be drawn.
     fn get_inner_position(&self) -> (u16, u16) {
         (self.x + 1, self.y + 1)
     }
 }
 
 impl Widget for Container {
+    /// Draws the container and its content.
+    ///
+    /// This method:
+    /// 1. Draws the border with optional color
+    /// 2. Creates a constrained view for the content
+    /// 3. Draws the content within the view
     fn draw(&self, window: &mut dyn Window) -> Result<()> {
         // Draw borders...
         if let Some(color) = self.border_color {
@@ -159,10 +255,12 @@ impl Widget for Container {
         Ok(())
     }
 
+    /// Returns the container's total size including borders.
     fn get_size(&self) -> (u16, u16) {
         (self.width, self.height)
     }
 
+    /// Returns the container's position.
     fn get_position(&self) -> (u16, u16) {
         (self.x, self.y)
     }

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -1,14 +1,28 @@
 use crate::{Window, Result, ColorPair, Color};
 use super::Widget;
 
-#[derive(Debug, Clone, Copy)]
-pub enum Alignment {
-    Left,
-    Center,
-    Right,
-}
-
-/// Widget for displaying text with optional styling
+/// A widget for displaying a single line of text with optional styling.
+///
+/// Label is a basic widget that renders a single line of text with support for:
+/// - Text colors
+/// - Background colors
+/// - Horizontal alignment
+/// - Dynamic text updates
+///
+/// Labels automatically handle text positioning based on their alignment
+/// and the available space in their parent container. Centering outside a
+/// container will center the label inside the terminal window area.
+///
+/// # Example
+///
+/// ```rust
+/// use minui::{Label, Color, Alignment};
+///
+/// // Create a centered, blue label
+/// let label = Label::new(0, 0, "Status: Ready")
+///     .with_text_color(Color::Blue)
+///     .with_alignment(Alignment::Center);
+/// ```
 pub struct Label {
     x: u16,
     y: u16,
@@ -17,7 +31,38 @@ pub struct Label {
     alignment: Alignment,
 }
 
+/// Text alignment options for label positioning.
+///
+/// Controls how text is positioned horizontally within the available space.
+///
+/// # Example
+///
+/// ```rust
+/// use minui::{Label, Alignment};
+///
+/// let centered_label = Label::new(0, 0, "Title")
+///     .with_alignment(Alignment::Center);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub enum Alignment {
+    Left,
+    Center,
+    Right,
+}
+
 impl Label {
+    /// Creates a new label at the specified position with the given text.
+    ///
+    /// By default, the label:
+    /// - Uses no colors (terminal default)
+    /// - Is left-aligned
+    /// - Has height of 1 character
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let label = Label::new(0, 0, "Hello, World!");
+    /// ```
     pub fn new(x: u16, y: u16, text: impl Into<String>) -> Self {
         Self {
             x,
@@ -28,38 +73,90 @@ impl Label {
         }
     }
 
-    /// Builder method to set the label's colors
+    /// Sets both foreground and background colors for the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use minui::{Color, ColorPair};
+    ///
+    /// let label = Label::new(0, 0, "Warning")
+    ///     .with_color(ColorPair::new(Color::Yellow, Color::Black));
+    /// ```
     pub fn with_color(mut self, colors: ColorPair) -> Self {
         self.colors = Some(colors);
         self
     }
 
+    /// Sets only the text color, leaving the background transparent.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let label = Label::new(0, 0, "Error")
+    ///     .with_text_color(Color::Red);
+    /// ```
     pub fn with_text_color(mut self, color: Color) -> Self {
         self.colors = Some(ColorPair::new(color, Color::Transparent));
         self
     }
 
+    /// Sets the horizontal alignment of the label text.
+    ///
+    /// The text will be aligned within the available space of its
+    /// parent container or window.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let label = Label::new(0, 0, "Title")
+    ///     .with_alignment(Alignment::Center);
+    /// ```
     pub fn with_alignment(mut self, alignment: Alignment) -> Self {
         self.alignment = alignment;
         self
     }
 
-    /// Updates the labels text
+    /// Updates the label's text content.
+    ///
+    /// This method can be used to change the text dynamically
+    /// after the label is created.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let mut label = Label::new(0, 0, "Loading...");
+    /// // Later:
+    /// label.set_text("Complete!");
+    /// ```
     pub fn set_text(&mut self, text: impl Into<String>) {
         self.text = text.into();
     }
 
-    /// Returns the current text contents
+    /// Returns the current text content of the label.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let label = Label::new(0, 0, "Status");
+    /// assert_eq!(label.text(), "Status");
+    /// ```
     pub fn text(&self) -> &str {
         &self.text
     }
 
-    /// Returns the length of the label string
+    /// Returns the length of the label text in characters.
+    ///
+    /// This is used internally for alignment calculations and
+    /// can be helpful for layout management.
     pub fn get_length(&self) -> u16 {
         self.text.len() as u16
     }
 
-    /// Calculate the actual x position based on alignment and available width
+    /// Calculates the actual x-coordinate based on alignment and available width.
+    ///
+    /// This internal method handles the positioning logic for different
+    /// alignment modes. If no width is provided, uses the label's original x position.
     fn calculate_aligned_x(&self, available_width: Option<u16>) -> u16 {
         if let Some(width) = available_width {
             let text_length = self.get_length();
@@ -87,6 +184,12 @@ impl Label {
 }
 
 impl Widget for Label {
+    /// Draws the label text with the configured styling and alignment.
+    ///
+    /// This method:
+    /// 1. Calculates the proper position based on alignment
+    /// 2. Applies any configured colors
+    /// 3. Writes the text to the window
     fn draw(&self, window: &mut dyn Window) -> Result<()> {
         // Get window size to calculate available width
         let (window_width, _) = window.get_size();
@@ -98,11 +201,18 @@ impl Widget for Label {
         }
     }
 
+    /// Returns the size of the label (width, height).
+    ///
+    /// The width is the length of the text in characters,
+    /// and the height is always 1 for single-line labels.
     fn get_size(&self) -> (u16, u16) {
         // Width is the text length, height is always 1 for a simple/short label
         (self.text.chars().count() as u16, 1)
     }
 
+    /// Returns the base position of the label.
+    ///
+    /// Note that the actual drawing position may differ due to alignment.
     fn get_position(&self) -> (u16, u16) {
         (self.x, self.y)
     }

--- a/src/widgets/panel.rs
+++ b/src/widgets/panel.rs
@@ -1,6 +1,30 @@
 use crate::{Color, ColorPair, Window};
 use super::{Alignment, BorderChars, TextBlock, Widget, WindowView};
 
+/// A sectioned panel widget with a header and body area.
+///
+/// Panel provides a more structured container than a basic Container,
+/// with distinct header and body sections that can be styled independently.
+/// Features include:
+/// - Optional header with centered text
+/// - Separate border styles for header and body
+/// - Independent colors for borders and content
+/// - Support for both simple text and TextBlock content
+/// - Automatic sizing based on content
+/// - Content padding and alignment
+///
+/// # Example
+///
+/// ```rust
+/// use minui::{Panel, Color, BorderChars};
+///
+/// let panel = Panel::new(0, 0, 40, 10)
+///     .with_header("System Status")
+///     .with_header_border_color(Color::Blue)
+///     .with_body("All systems operational")
+///     .with_body_color(Some(ColorPair::new(Color::Green, Color::Black)))
+///     .with_padding(1);
+/// ```
 pub struct Panel {
     x: u16,
     y: u16,
@@ -19,12 +43,46 @@ pub struct Panel {
     auto_size: bool,
 }
 
+/// Content types that can be displayed in a panel's body section.
+///
+/// Supports both simple text strings and more complex TextBlock widgets
+/// that provide additional formatting capabilities.
+///
+/// # Example
+///
+/// ```rust
+/// use minui::{Panel, TextBlock, TextWrapMode};
+///
+/// // Simple text content
+/// let text_panel = Panel::new(0, 0, 40, 10)
+///     .with_body("Simple text content");
+///
+/// // TextBlock content with word wrapping
+/// let block = TextBlock::new(0, 0, 38, 8, "Long text content...")
+///     .with_wrap_mode(TextWrapMode::WrapWords);
+/// let block_panel = Panel::new(0, 0, 40, 10)
+///     .with_body_block(block);
+/// ```
 pub enum PanelContent {
     Text(String),
     Block(Box<TextBlock>),
 }
 
 impl Panel {
+    /// Creates a new panel with the specified position and size.
+    ///
+    /// By default, the panel:
+    /// - Has no header text
+    /// - Has empty body content
+    /// - Uses single-line borders for both sections
+    /// - Has 1 unit of padding
+    /// - Auto-sizes based on content
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let panel = Panel::new(0, 0, 40, 10);
+    /// ```
     pub fn new(x: u16, y: u16, width: u16, height: u16) -> Self {
        Self {
            x,
@@ -45,6 +103,17 @@ impl Panel {
        }
     }
 
+    /// Sets the panel's header text.
+    ///
+    /// The header text is automatically centered in the header section.
+    /// If auto-sizing is enabled, the panel width may adjust to fit the text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let panel = Panel::new(0, 0, 40, 10)
+    ///     .with_header("Configuration");
+    /// ```
     pub fn with_header(mut self, text: impl Into<String>) -> Self {
         self.header_text = text.into();
         if self.auto_size {
@@ -53,6 +122,17 @@ impl Panel {
         self
     }
 
+    /// Sets the panel's body content as simple text.
+    ///
+    /// The text will be aligned according to the panel's alignment setting
+    /// and will wrap at line breaks.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let panel = Panel::new(0, 0, 40, 10)
+    ///     .with_body("Status: Online\nAll systems normal");
+    /// ```
     pub fn with_body(mut self, text: impl Into<String>) -> Self {
         self.body_content = PanelContent::Text(text.into());
         if self.auto_size {
@@ -61,6 +141,23 @@ impl Panel {
         self
     }
 
+    /// Sets the panel's body content using a TextBlock.
+    ///
+    /// TextBlocks provide additional formatting capabilities like:
+    /// - Word wrapping
+    /// - Vertical alignment
+    /// - Scrolling
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use minui::{TextBlock, TextWrapMode};
+    ///
+    /// let text_block = TextBlock::new(0, 0, 38, 8, "Long content...")
+    ///     .with_wrap_mode(TextWrapMode::WrapWords);
+    /// let panel = Panel::new(0, 0, 40, 10)
+    ///     .with_body_block(text_block);
+    /// ```
     pub fn with_body_block(mut self, text_block: TextBlock) -> Self {
         self.body_content = PanelContent::Block(Box::new(text_block));
         if self.auto_size {
@@ -69,59 +166,158 @@ impl Panel {
         self
     }
 
+    /// Sets the panel's header border style (single-line, double-line, ascii)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let panel = Panel::new(0, 0, 40, 10)
+    ///     .with_header_style(BorderChars::double_line());
+    /// ```
     pub fn with_header_style(mut self, style: BorderChars) -> Self {
         self.header_style = style;
         self
     }
 
+    /// Sets the panel's body border style (single-line, double-line, ascii)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let panel = Panel::new(0, 0, 40, 10)
+    ///     .with_body_style(BorderChars::single_line());
+    /// ```
     pub fn with_body_style(mut self, style: BorderChars) -> Self {
         self.body_style = style;
         self
     }
 
+    /// Sets the panel's header text color
+    /// Sets the text color for the panel's header.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let panel = Panel::new(0, 0, 40, 10)
+    ///     .with_header_color(Some(ColorPair::new(Color::Yellow, Color::Black)));
+    /// ```
     pub fn with_header_color(mut self, color: Option<ColorPair>) -> Self {
         self.header_color = color;
         self
     }
 
+    /// Sets the panel's body text color
+    /// Sets the text color for the panel's body content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let panel = Panel::new(0, 0, 40, 10)
+    ///     .with_body_color(Some(ColorPair::new(Color::White, Color::Blue)));
+    /// ```
     pub fn with_body_color(mut self, color: Option<ColorPair>) -> Self {
         self.body_color = color;
         self
     }
 
+    /// Sets the panel's header border color
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let panel = Panel::new(0, 0, 40, 10)
+    ///     .with_header_border_color(Color::Blue);
+    /// ```
     pub fn with_header_border_color(mut self, color: Color) -> Self {
         self.header_border_color = Some(ColorPair::new(color, Color::Transparent));
         self
     }
 
+
+    /// Sets the panel's body border color
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let panel = Panel::new(0, 0, 40, 10)
+    ///     .with_body_border_color(Color::Blue);
+    /// ```
     pub fn with_body_border_color(mut self, color: Color) -> Self {
         self.body_border_color = Some(ColorPair::new(color, Color::Transparent));
         self
     }
 
+    /// Sets the padding between the panel's borders and its body content.
+    ///
+    /// The padding is applied equally to both sides of the body content.
+    /// Header text is not affected by padding.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let panel = Panel::new(0, 0, 40, 10)
+    ///     .with_padding(2);  // 2 units of padding on each side
+    /// ```
     pub fn with_padding(mut self, padding: u16) -> Self {
         self.padding = padding;
         self
     }
 
+    /// Sets the horizontal alignment of the panel's body content.
+    ///
+    /// Note: Header text is always centered regardless of this setting.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let panel = Panel::new(0, 0, 40, 10)
+    ///     .with_alignment(Alignment::Center);  // Center body content
+    /// ```
     pub fn with_alignment(mut self, alignment: Alignment) -> Self {
         self.alignment = alignment;
         self
     }
 
+    /// Updates the panel's header text.
+    ///
+    /// If auto-sizing is enabled, the panel may resize to fit the new text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let mut panel = Panel::new(0, 0, 40, 10);
+    /// panel.set_header("New Header");
+    /// ```
     pub fn set_header(&mut self, text: impl Into<String>) {
         self.header_text = text.into();
     }
 
+    /// Updates the panel's body text content.
+    ///
+    /// If auto-sizing is enabled, the panel may resize to fit the new text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let mut panel = Panel::new(0, 0, 40, 10);
+    /// panel.set_body("New content");
+    /// ```
     pub fn set_body(&mut self, text: impl Into<String>) {
         self.body_content = PanelContent::Text(text.into());
     }
 
+    /// Sets whether the panel should auto-size around the contents
     pub fn with_auto_size(mut self, auto_size: bool) -> Self {
         self.auto_size = auto_size;
         self
     }
 
+    /// Dynamically updates the panel's size based on its content.
+    ///
+    /// Calculates the required dimensions to fit:
+    /// - Header text plus padding
+    /// - Body content plus padding
+    /// - Border characters
     fn adjust_size(&mut self) {
         // Calculate required width
         let header_width = self.header_text.len() as u16 + 4;
@@ -151,6 +347,12 @@ impl Panel {
         self.height = body_height + 5; // 3 lines for the header + body content + bottom border
     }
 
+    /// Returns the available space for content within the panel's borders.
+    ///
+    /// The inner dimensions account for:
+    /// - Border width (2 characters)
+    /// - Header height (3 characters)
+    /// - Bottom border (1 character)
     fn get_inner_dimensions(&self) -> (u16, u16) {
         let inner_width = self.width.saturating_sub(2);
         let inner_height = self.height.saturating_sub(4);
@@ -159,6 +361,14 @@ impl Panel {
 }
 
 impl Widget for Panel {
+    /// Draws the complete panel including header, borders, and content.
+    ///
+    /// The drawing process:
+    /// 1. Draws the header section with its borders
+    /// 2. Draws the centered header text
+    /// 3. Draws the separator between header and body
+    /// 4. Draws the body borders
+    /// 5. Draws the body content with proper alignment
     fn draw(&self, window: &mut dyn Window) -> crate::Result<()> {
         // Draw header section
         if let Some(color) = self.header_border_color {
@@ -301,10 +511,12 @@ impl Widget for Panel {
         Ok(())
     }
 
+    /// Returns the panel's total size including borders.
     fn get_size(&self) -> (u16, u16) {
         (self.width, self.height)
     }
 
+    /// Returns the panel's (top-left corner) position.
     fn get_position(&self) -> (u16, u16) {
         (self.x, self.y)
     }

--- a/src/widgets/text_block.rs
+++ b/src/widgets/text_block.rs
@@ -1,6 +1,18 @@
 use crate::{Window, Result, ColorPair};
 use super::{Alignment, Widget};
 
+/// Text wrapping modes for multi-line text display.
+///
+/// Controls how text is wrapped when it exceeds the widget's width.
+///
+/// # Example
+///
+/// ```rust
+/// use minui::{TextBlock, TextWrapMode};
+///
+/// let block = TextBlock::new(0, 0, 40, 10, "Long text content...")
+///     .with_wrap_mode(TextWrapMode::WrapWords);
+/// ```
 #[derive(Debug, Clone, Copy)]
 pub enum TextWrapMode {
     None,           // No wrapping, clip text
@@ -8,6 +20,18 @@ pub enum TextWrapMode {
     WrapWords,      // Wrap at word boundaries
 }
 
+/// Text wrapping modes for multi-line text display.
+///
+/// Controls how text is wrapped when it exceeds the widget's width.
+///
+/// # Example
+///
+/// ```rust
+/// use minui::{TextBlock, TextWrapMode};
+///
+/// let block = TextBlock::new(0, 0, 40, 10, "Long text content...")
+///     .with_wrap_mode(TextWrapMode::WrapWords);
+/// ```
 #[derive(Debug, Clone, Copy)]
 pub enum VerticalAlignment {
     Top,
@@ -15,6 +39,27 @@ pub enum VerticalAlignment {
     Bottom,
 }
 
+/// A widget for displaying and formatting multi-line text.
+///
+/// TextBlock provides advanced text formatting capabilities including:
+/// - Text wrapping with different modes
+/// - Horizontal and vertical alignment
+/// - Scrollable content
+/// - Color styling
+///
+/// It's ideal for displaying longer text content that needs formatting
+/// control beyond what Label provides.
+///
+/// # Example
+///
+/// ```rust
+/// use minui::{TextBlock, TextWrapMode, Alignment, VerticalAlignment, Color, ColorPair};
+///
+/// let block = TextBlock::new(0, 0, 40, 10, "Multi-line\ntext content")
+///     .with_wrap_mode(TextWrapMode::WrapWords)
+///     .with_alignment(Alignment::Left, VerticalAlignment::Top)
+///     .with_colors(ColorPair::new(Color::White, Color::Blue));
+/// ```
 pub struct TextBlock {
     x: u16,
     y: u16,
@@ -29,6 +74,20 @@ pub struct TextBlock {
 }
 
 impl TextBlock {
+    /// Creates a new text block with the specified position, size, and content.
+    ///
+    /// By default, the text block:
+    /// - Uses character-based wrapping
+    /// - Is left-aligned horizontally
+    /// - Is top-aligned vertically
+    /// - Has no color styling
+    /// - Starts with no scroll offset
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let block = TextBlock::new(0, 0, 40, 10, "Hello\nWorld");
+    /// ```
     pub fn new(x: u16, y: u16, width: u16, height: u16, text: impl Into<String>) -> Self {
         Self {
             x,
@@ -44,23 +103,61 @@ impl TextBlock {
         }
     }
 
+    /// Sets the text colors for the entire block.
+    ///
+    /// Applies the specified colors to all text within the block.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let block = TextBlock::new(0, 0, 40, 10, "Styled text")
+    ///     .with_colors(ColorPair::new(Color::White, Color::Blue));
+    /// ```
     pub fn with_colors(mut self, colors: ColorPair) -> Self {
         self.colors = Some(colors);
         self
     }
 
+    /// Sets the text wrapping mode.
+    ///
+    /// Changes how text is wrapped when it exceeds the block's width:
+    /// - `None`: Text is clipped at the boundary
+    /// - `Wrap`: Text wraps at exact character positions
+    /// - `WrapWords`: Text wraps at word boundaries
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let block = TextBlock::new(0, 0, 40, 10, "Long text...")
+    ///     .with_wrap_mode(TextWrapMode::WrapWords);
+    /// ```
     pub fn with_wrap_mode(mut self, mode: TextWrapMode) -> Self {
         self.wrap_mode = mode;
         self
     }
 
+    /// Sets both horizontal and vertical alignment.
+    ///
+    /// Controls how text is positioned within the block's bounds:
+    /// - Horizontal alignment affects each line
+    /// - Vertical alignment affects the entire text body
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let block = TextBlock::new(0, 0, 40, 10, "Centered text")
+    ///     .with_alignment(Alignment::Center, VerticalAlignment::Middle);
+    /// ```
     pub fn with_alignment(mut self, h_align: Alignment, v_align: VerticalAlignment) -> Self {
         self.h_align = h_align;
         self.v_align = v_align;
         self
     }
 
-    // Calculate wrapped lines based on width and wrap_mode
+    /// Calculates the wrapped lines based on the current wrap mode.
+    ///
+    /// This internal method handles the text wrapping logic for all
+    /// three wrapping modes, considering the block's width.
     fn get_wrapped_lines(&self) -> Vec<String> {
         match self.wrap_mode {
             TextWrapMode::None => self.text.lines().map(String::from).collect(),
@@ -100,10 +197,35 @@ impl TextBlock {
         }
     }
 
+    /// Scrolls the text to a specific line number.
+    ///
+    /// Sets which line appears at the top of the visible area.
+    /// The scroll offset is clamped to prevent scrolling beyond
+    /// the available content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let mut block = TextBlock::new(0, 0, 40, 10, "Line 1\nLine 2\nLine 3");
+    /// block.scroll_to(1);  // Scroll to show Line 2 at the top
+    /// ```
     pub fn scroll_to(&mut self, line: u16) {
         self.scroll_offset = line;
     }
 
+    /// Scrolls the text by a relative number of lines.
+    ///
+    /// Positive values scroll down, negative values scroll up.
+    /// The scroll offset is clamped to prevent scrolling beyond
+    /// the available content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let mut block = TextBlock::new(0, 0, 40, 10, "Multi-line content");
+    /// block.scroll_by(2);   // Scroll down 2 lines
+    /// block.scroll_by(-1);  // Scroll up 1 line
+    /// ```
     pub fn scroll_by(&mut self, delta: i16) {
         self.scroll_offset = if delta.is_negative() {
             self.scroll_offset.saturating_sub(delta.abs() as u16)
@@ -114,6 +236,13 @@ impl TextBlock {
 }
 
 impl Widget for TextBlock {
+    /// Draws the text block with all current formatting options applied.
+    ///
+    /// This method handles:
+    /// 1. Text wrapping according to the wrap mode
+    /// 2. Positioning based on alignments
+    /// 3. Scroll offset application
+    /// 4. Color styling
     fn draw(&self, window: &mut dyn Window) -> Result<()> {
         let lines = self.get_wrapped_lines();
         let (window_width, window_height) = window.get_size();
@@ -179,11 +308,12 @@ impl Widget for TextBlock {
         Ok(())
     }
 
-
+    /// Returns the block's total size.
     fn get_size(&self) -> (u16, u16) {
         (self.width, self.height)
     }
 
+    /// Returns the block's (top-left corner) position.
     fn get_position(&self) -> (u16, u16) {
         (self.x, self.y)
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,3 +1,16 @@
+//! Terminal window management and core display functionality.
+//!
+//! This module provides the foundational interfaces and implementations for
+//! terminal window management, including:
+//! - Basic text output with positioning
+//! - Color and style support
+//! - Input handling
+//! - Terminal state management
+//!
+//! The main types are:
+//! - [`Window`]: A trait defining the core interface for window-like objects
+//! - [`TerminalWindow`]: A concrete implementation managing the actual terminal
+
 use std::io::{Write, stdout};
 use crossterm::{
     terminal::{self, enable_raw_mode, disable_raw_mode},
@@ -8,21 +21,139 @@ use crossterm::{
 };
 use crate::{Error, Result, Event, ColorPair};
 
-/// Trait defining the interface for window-like objects
+/// A trait defining the core interface for window-like objects that can display text
+/// and handle basic styling.
+///
+/// This trait provides the fundamental operations needed for terminal-based user interfaces:
+/// - Writing text at specific positions
+/// - Applying colors and styles to text
+/// - Querying window dimensions
+///
+/// Implementors of this trait can represent actual terminal windows, virtual buffers,
+/// or other display-like objects that support positioned text output.
 pub trait Window {
+    /// Writes a string at the specified position (y, x) without styling.
+    ///
+    /// The position is specified in (row, column) format, where (0, 0) is the top-left
+    /// corner of the window. The text will be written from left to right starting at
+    /// the specified position.
+    ///
+    /// # Arguments
+    /// * `y` - The vertical position (row) where the text should start
+    /// * `x` - The horizontal position (column) where the text should start
+    /// * `s` - The string to write
+    ///
+    /// # Returns
+    /// * `Ok(())` if the write was successful
+    /// * `Err(Error::WindowError)` if the position is out of bounds
+    /// * `Err(Error::IoError)` if there was an error writing to the terminal
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// window.write_str(0, 0, "Hello, world!")?;
+    /// ```
     fn write_str(&mut self, y: u16, x: u16, s: &str) -> Result<()>;
+
+    /// Writes a colored string at the specified position (y, x).
+    ///
+    /// Similar to `write_str`, but applies the specified colors to the text.
+    /// The colors will remain in effect only for the specified string.
+    ///
+    /// # Arguments
+    /// * `y` - The vertical position (row) where the text should start
+    /// * `x` - The horizontal position (column) where the text should start
+    /// * `s` - The string to write
+    /// * `colors` - The foreground and background colors to apply
+    ///
+    /// # Returns
+    /// * `Ok(())` if the write was successful
+    /// * `Err(Error::WindowError)` if the position is out of bounds
+    /// * `Err(Error::IoError)` if there was an error writing to the terminal
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let colors = ColorPair::new(Color::Green, Color::Black);
+    /// window.write_str_colored(1, 0, "Success!", colors)?;
+    /// ```
     fn write_str_colored(&mut self, y: u16, x: u16, s: &str, colors: ColorPair) -> Result<()>;
+
+    /// Returns the current size of the window as (width, height) in characters.
+    ///
+    /// # Returns
+    /// A tuple of (width, height) representing the window dimensions in character cells.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let (width, height) = window.get_size();
+    /// println!("Window is {} columns by {} rows", width, height);
+    /// ```
     fn get_size(&self) -> (u16, u16);
 }
 
-/// Manages the terminal window and provides methods for drawing and input handling
+/// Manages the terminal window and provides methods for drawing and handling input.
+///
+/// `TerminalWindow` provides a concrete implementation of the [`Window`] trait for
+/// actual terminal windows. It handles:
+/// - Raw mode configuration for immediate character-by-character input
+/// - Alternate screen buffer management to preserve the original terminal content
+/// - Cursor visibility control
+/// - Automatic terminal cleanup when dropped
+///
+/// When a `TerminalWindow` is created, it:
+/// 1. Enables raw mode for immediate input handling
+/// 2. Switches to the alternate screen buffer
+/// 3. Clears the screen
+/// 4. Hides the cursor
+///
+/// When dropped, it automatically:
+/// 1. Disables raw mode
+/// 2. Restores the cursor
+/// 3. Switches back to the main screen buffer
+///
+/// # Example
+///
+/// ```rust
+/// use minui::TerminalWindow;
+///
+/// fn main() -> Result<()> {
+///     let mut window = TerminalWindow::new()?;
+///     window.write_str(0, 0, "Press 'q' to quit")?;
+///
+///     loop {
+///         if let Event::Character('q') = window.get_input()? {
+///             break;
+///         }
+///     }
+///     Ok(())
+/// }
+/// ```
 pub struct TerminalWindow {
     width: u16,
     height: u16,
 }
 
 impl TerminalWindow {
-    /// Creates a new terminal window and configures it for raw mode
+    /// Creates a new terminal window and configures it for raw mode.
+    ///
+    /// This method performs the following setup:
+    /// 1. Enables raw mode for immediate character input
+    /// 2. Gets the current terminal size
+    /// 3. Switches to the alternate screen buffer
+    /// 4. Clears the screen
+    /// 5. Hides the cursor
+    ///
+    /// # Returns
+    /// * `Ok(TerminalWindow)` if initialization was successful
+    /// * `Err(Error::IoError)` if any terminal operations failed
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let mut window = TerminalWindow::new()?;
+    /// ```
     pub fn new() -> Result<Self> {
         enable_raw_mode()?;
 
@@ -42,7 +173,18 @@ impl TerminalWindow {
         })
     }
 
-    /// Clears the entire terminal screen
+    /// Clears the entire terminal screen and resets cursor position to (0, 0).
+    ///
+    /// # Returns
+    /// * `Ok(())` if the clear operation was successful
+    /// * `Err(Error::IoError)` if the terminal operation failed
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// window.clear()?;
+    /// window.write_str(0, 0, "Fresh start")?;
+    /// ```
     pub fn clear(&self) -> Result<()> {
         execute!(
             stdout(),
@@ -52,7 +194,32 @@ impl TerminalWindow {
         Ok(())
     }
 
-    /// Polls for and returns the next keyboard input
+    /// Polls for and returns the next keyboard input event.
+    ///
+    /// This method will wait up to 100ms for input. If no input is received
+    /// within that time, it returns `Event::Unknown`.
+    ///
+    /// # Returns
+    /// * `Ok(Event)` containing the detected key event
+    /// * `Err(Error::IoError)` if there was an error reading input
+    ///
+    /// The returned `Event` will be one of:
+    /// - `Event::Character(char)` for regular character input
+    /// - `Event::KeyUp`, `KeyDown`, `KeyLeft`, `KeyRight` for arrow keys
+    /// - `Event::Delete` or `Event::Backspace` for deletion keys
+    /// - `Event::Enter` for the enter/return key
+    /// - `Event::FunctionKey(u8)` for F1-F12 keys
+    /// - `Event::Unknown` for unhandled keys or timeout
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// match window.get_input()? {
+    ///     Event::Character('q') => break,
+    ///     Event::KeyUp => move_cursor_up(),
+    ///     _ => (),
+    /// }
+    /// ```
     pub fn get_input(&self) -> Result<Event> {
         if event::poll(std::time::Duration::from_millis(100))? {
             if let CrosstermEvent::Key(key) = event::read()? {
@@ -114,7 +281,14 @@ impl Window for TerminalWindow {
 }
 
 impl Drop for TerminalWindow {
-    /// Cleans the terminal state
+    /// Cleans up the terminal state when the window is dropped.
+    ///
+    /// This ensures the terminal is returned to a usable state by:
+    /// 1. Disabling raw mode
+    /// 2. Resetting colors
+    /// 3. Clearing the screen
+    /// 4. Showing the cursor
+    /// 5. Returning to the main screen buffer
     fn drop(&mut self) {
         let _ = disable_raw_mode();
 


### PR DESCRIPTION
Might have gone a bit overboard, but better safe than sorry!

For some reason, all of the usage examples are being flagged in my IDE as errors because of import shenanigans, so I might remove those at some point if I can't figure out how to disable those error checks.